### PR TITLE
Implement mock server and automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ temp/
 # Others
 *.swp
 .npm/
+!server.js

--- a/README.md
+++ b/README.md
@@ -27,3 +27,29 @@ O fluxo de autenticação envia usuário e senha para a API, grava o token no `l
 - Teste unitário simples para o `AuthGuard`.
 
 Futuramente é possível ampliar os testes, tratar renovação de token e armazenar o JWT de forma mais segura.
+
+## Mock da API
+
+Execute o servidor de mock para simular `/auth/login` e `/usuario`:
+
+```bash
+npm run start:mock
+```
+
+A API ficará disponível em `http://localhost:3000`.
+
+## Testes
+
+- **Unitários:**
+
+```bash
+npm test
+```
+
+- **End to End (Cypress):**
+
+```bash
+npx cypress run
+```
+
+Para visualizar a cobertura utilize `ng test --code-coverage` e abra `coverage/index.html`.

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4200'
+  }
+});

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,0 +1,10 @@
+describe('Login flow', () => {
+  it('logs in and displays chart', () => {
+    cy.visit('/auth/login');
+    cy.get('#username').type('admin');
+    cy.get('#password').type('123');
+    cy.contains('button', 'Entrar').click();
+    cy.url().should('include', '/home');
+    cy.get('canvas').should('be.visible');
+  });
+});

--- a/cypress/e2e/protect.cy.ts
+++ b/cypress/e2e/protect.cy.ts
@@ -1,0 +1,6 @@
+describe('Route guard', () => {
+  it('redirects to login without token', () => {
+    cy.visit('/users', { failOnStatusCode: false });
+    cy.url().should('include', '/auth/login');
+  });
+});

--- a/cypress/e2e/users.cy.ts
+++ b/cypress/e2e/users.cy.ts
@@ -1,0 +1,13 @@
+describe('User list', () => {
+  it('shows users table', () => {
+    cy.window().then(win => {
+      win.localStorage.setItem('token', 'fake');
+    });
+    cy.intercept('GET', '/usuario', [
+      { login: 'alice', email: 'alice@example.com' },
+      { login: 'bob', email: 'bob@example.com' }
+    ]);
+    cy.visit('/users');
+    cy.get('table tbody tr').should('have.length', 2);
+  });
+});

--- a/db.json
+++ b/db.json
@@ -1,0 +1,6 @@
+{
+  "users": [
+    { "id": 1, "name": "Alice", "email": "alice@example.com" },
+    { "id": 2, "name": "Bob", "email": "bob@example.com" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ng test --project jwt-auth-angular",
     "lint": "ng lint --project jwt-auth-angular",
     "format": "prettier --write \"src/**/*.ts\"",
-    "e2e": "ng e2e --project jwt-auth-angular"
+    "e2e": "ng e2e --project jwt-auth-angular",
+    "start:mock": "node server.js"
   },
   "private": true,
   "dependencies": {
@@ -38,6 +39,8 @@
     "@angular-eslint/eslint-plugin": "^16.2.0",
     "@angular-eslint/eslint-plugin-template": "^16.2.0",
     "@angular-eslint/template-parser": "^16.2.0",
-    "prettier": "^2.8.8"
+    "prettier": "^2.8.8",
+    "json-server": "^0.17.3",
+    "cypress": "^13.2.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,20 @@
+const jsonServer = require('json-server');
+const server = jsonServer.create();
+const router = jsonServer.router('db.json');
+const middlewares = jsonServer.defaults();
+
+server.use(middlewares);
+server.use(jsonServer.bodyParser);
+
+server.post('/auth/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === 'admin' && password === '123') {
+    return res.json({ token: 'fake-jwt-token' });
+  }
+  res.status(401).json({ message: 'Unauthorized' });
+});
+
+server.use(router);
+server.listen(3000, () => {
+  console.log('JSON Server running at http://localhost:3000');
+});

--- a/src/app/core/auth.service.spec.ts
+++ b/src/app/core/auth.service.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import { environment } from '../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AuthService]
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should save token on login', () => {
+    service.login('admin', '123').subscribe();
+    const req = httpMock.expectOne(`${environment.apiBase}/auth/signin`);
+    req.flush({ token: 'test-token' });
+    expect(localStorage.getItem('token')).toBe('test-token');
+  });
+
+  it('should return stored token', () => {
+    localStorage.setItem('token', 'abc');
+    expect(service.getToken()).toBe('abc');
+  });
+});

--- a/src/app/core/token.interceptor.spec.ts
+++ b/src/app/core/token.interceptor.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { TokenInterceptor } from './token.interceptor';
+import { AuthService } from './auth.service';
+
+describe('TokenInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        AuthService,
+        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true }
+      ]
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+    localStorage.setItem('token', 'abc.def.ghi');
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    localStorage.clear();
+  });
+
+  it('should add Authorization header', () => {
+    http.get('/data').subscribe();
+    const req = httpMock.expectOne('/data');
+    expect(req.request.headers.get('Authorization')).toBe('Bearer abc.def.ghi');
+  });
+});


### PR DESCRIPTION
## Summary
- add json-server mock and mock data
- expand README with mock and test instructions
- add Cypress config and e2e test examples
- create unit tests for AuthService and TokenInterceptor

## Testing
- `npm test` *(fails: ng not found)*