### PR TITLE
Implement global footer

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,3 +6,4 @@
 <div class="content-wrapper">
   <router-outlet></router-outlet>
 </div>
+<app-footer></app-footer>

--- a/src/app/shared/footer/footer.component.css
+++ b/src/app/shared/footer/footer.component.css
@@ -1,0 +1,6 @@
+.app-footer {
+  text-align: center;
+  padding: 1rem 0;
+  background: #f0f0f0;
+  color: #555;
+}

--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -1,0 +1,3 @@
+<footer class="app-footer">
+  Desenvolvido por <strong>Gustavo Vasconcelos</strong> - Teste de desenvolvimento frontend para fins de avaliação
+</footer>

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  templateUrl: './footer.component.html',
+  styleUrls: ['./footer.component.css']
+})
+export class FooterComponent {}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,8 +8,10 @@ import { CardModule } from 'primeng/card';
 import { MenubarModule } from 'primeng/menubar';
 import { MessageModule } from 'primeng/message';
 import { ChartModule } from 'primeng/chart';
+import { FooterComponent } from './footer/footer.component';
 
 @NgModule({
+  declarations: [FooterComponent],
   imports: [
     CommonModule,
     TableModule,
@@ -29,7 +31,8 @@ import { ChartModule } from 'primeng/chart';
     CardModule,
     MenubarModule,
     MessageModule,
-    ChartModule
+    ChartModule,
+    FooterComponent
   ]
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary
- add a `FooterComponent` inside `shared`
- export the footer through `SharedModule`
- include `<app-footer>` in the root component so it appears on every page

## Testing
- `npm test` *(fails: ng not found)*