### PR TITLE
Fix login endpoint for local mock API

### DIFF
--- a/src/app/core/auth.service.spec.ts
+++ b/src/app/core/auth.service.spec.ts
@@ -23,7 +23,7 @@ describe('AuthService', () => {
 
   it('should save token on login', () => {
     service.login('demo-gustavo@gmail.com', '123456').subscribe();
-    const req = httpMock.expectOne(`${environment.apiBase}/auth/signin`);
+    const req = httpMock.expectOne(`${environment.apiBase}/auth/login`);
     req.flush({ token: 'test-token' });
     expect(localStorage.getItem('token')).toBe('test-token');
   });

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -5,12 +5,17 @@ import { environment } from '../../environments/environment';
 
 @Injectable()
 export class AuthService {
+  // Base URL da API de autenticação
   private api = `${environment.apiBase}/auth`;
 
   constructor(private http: HttpClient) {}
 
+  /**
+   * Realiza o login enviando usuario e senha para o servidor.
+   * O endpoint configurado no server mock espera /auth/login.
+   */
   login(username: string, password: string) {
-    return this.http.post<{ token: string }>(`${this.api}/signin`, { username, password }).pipe(
+    return this.http.post<{ token: string }>(`${this.api}/login`, { username, password }).pipe(
       tap(res => localStorage.setItem('token', res.token))
     );
   }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,10 @@
 export const environment = {
   production: true,
-  apiBase: 'https://localhost:5001/api'
+  /**
+   * Base URL da API utilizada quando a aplicação
+   * estiver em produção. Manter o mesmo endpoint do
+   * servidor de mock para facilitar o build em
+   * ambientes locais.
+   */
+  apiBase: 'http://localhost:3000'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,9 @@
 export const environment = {
   production: false,
-  apiBase: 'https://localhost:5001/api'
+  /**
+   * Base URL da API utilizada em desenvolvimento. Por
+   * padrao o servidor mock roda em http://localhost:3000
+   * conforme instrucoes do README.
+   */
+  apiBase: 'http://localhost:3000'
 };


### PR DESCRIPTION
## Summary
- update environment API URLs to use localhost:3000
- adjust AuthService to call `/auth/login`
- update tests to new endpoint

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run lint` *(fails: `ng` not found)*
