### PR TITLE
Add social login icons

### DIFF
--- a/src/app/pages/login/login.component.css
+++ b/src/app/pages/login/login.component.css
@@ -175,6 +175,22 @@
   border-color: var(--primary-color);
 }
 
+.google-icon .pi {
+  color: #db4437;
+}
+
+.facebook-icon .pi {
+  color: #1877f2;
+}
+
+.github-icon .pi {
+  color: #000000;
+}
+
+.apple-icon .pi {
+  color: #000000;
+}
+
 @media (max-width: 480px) {
   .login-card {
     margin: 1rem;

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -60,8 +60,34 @@
       <div class="social-login">
         <p>Ou continue com</p>
         <div class="social-icons">
-          <button pButton type="button" icon="pi pi-google" class="p-button-rounded outlined"></button>
-          <button pButton type="button" icon="pi pi-facebook" class="p-button-rounded outlined"></button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-google"
+            class="p-button-rounded outlined google-icon"
+            aria-label="Google"
+          ></button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-facebook"
+            class="p-button-rounded outlined facebook-icon"
+            aria-label="Facebook"
+          ></button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-github"
+            class="p-button-rounded outlined github-icon"
+            aria-label="GitHub"
+          ></button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-apple"
+            class="p-button-rounded outlined apple-icon"
+            aria-label="Apple"
+          ></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add icon buttons for Google, Facebook, GitHub and Apple on login screen
- style social icon colors

## Testing
- `npm test` *(fails: ng not found)*