### PR TITLE
Fix social login icon colors

### DIFF
--- a/src/app/pages/login/login.component.css
+++ b/src/app/pages/login/login.component.css
@@ -175,19 +175,19 @@
   border-color: var(--primary-color);
 }
 
-.google-icon .fa {
+.google-icon .p-button-icon {
   color: #db4437;
 }
 
-.facebook-icon .fa {
+.facebook-icon .p-button-icon {
   color: #1877f2;
 }
 
-.github-icon .fa {
+.github-icon .p-button-icon {
   color: #000000;
 }
 
-.apple-icon .fa {
+.apple-icon .p-button-icon {
   color: #000000;
 }
 


### PR DESCRIPTION
## Summary
- fix the CSS selectors for social login icons so that their brand colors show up

## Testing
- `npm test` *(fails: ng not found)*
- `npx cypress run` *(fails: command not found)*