### PR TITLE
Fix login redirect when mock token lacks expiry

### DIFF
--- a/src/app/core/auth.guard.ts
+++ b/src/app/core/auth.guard.ts
@@ -3,7 +3,7 @@ import { CanActivate, Router } from '@angular/router';
 import { AuthService } from './auth.service';
 
 interface JwtPayload {
-  exp: number;
+  exp?: number;
 }
 
 @Injectable()
@@ -13,9 +13,12 @@ export class AuthGuard implements CanActivate {
   private tokenExpired(token: string): boolean {
     try {
       const payload = JSON.parse(atob(token.split('.')[1])) as JwtPayload;
+      if (!payload.exp) {
+        return false;
+      }
       return payload.exp * 1000 < Date.now();
     } catch {
-      return true;
+      return false;
     }
   }
 

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -41,10 +41,13 @@ export class LoginComponent implements OnInit {
    */
   private tokenExpired(token: string): boolean {
     try {
-      const payload = JSON.parse(atob(token.split('.')[1])) as { exp: number };
+      const payload = JSON.parse(atob(token.split('.')[1])) as { exp?: number };
+      if (!payload.exp) {
+        return false;
+      }
       return payload.exp * 1000 < Date.now();
     } catch {
-      return true;
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- relax JWT validation to support mock tokens without expiration
- let login page accept tokens without `exp`

## Testing
- `npm test` *(fails: ng not found)*