### PR TITLE
Add professional dashboard to home page

### DIFF
--- a/src/app/pages/home/home.component.css
+++ b/src/app/pages/home/home.component.css
@@ -1,5 +1,18 @@
 
-.home-container {
+.home-wrapper {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 2rem;
+  width: 100%;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.chart-card {
+  width: 100%;
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,6 +1,16 @@
 
-<div class="home-container p-m-4">
-  <p-card header="Dashboard">
+<div class="home-wrapper">
+  <div class="metrics-grid">
+    <app-metric-card
+      *ngFor="let metric of metrics"
+      [icon]="metric.icon"
+      [title]="metric.title"
+      [value]="metric.value"
+      [color]="metric.color"
+    ></app-metric-card>
+  </div>
+
+  <p-card header="Novos usuários por mês" class="chart-card">
     <p-chart type="bar" [data]="chartData"></p-chart>
   </p-card>
 </div>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -1,20 +1,54 @@
 import { Component } from '@angular/core';
 import { ChartData } from 'chart.js';
 
+interface Metric {
+  title: string;
+  value: string | number;
+  icon: string;
+  color: string;
+}
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css']
+  styleUrls: ['./home.component.css'],
 })
 export class HomeComponent {
+  metrics: Metric[] = [
+    {
+      title: 'Novos Usuários',
+      value: 1250,
+      icon: 'fa-solid fa-user-plus',
+      color: '#42A5F5',
+    },
+    {
+      title: 'Vendas',
+      value: 'R$ 12.400',
+      icon: 'fa-solid fa-shopping-cart',
+      color: '#66BB6A',
+    },
+    {
+      title: 'Satisfação',
+      value: '95%',
+      icon: 'fa-solid fa-face-smile',
+      color: '#FFA726',
+    },
+    {
+      title: 'Tempo Online',
+      value: '2h 30m',
+      icon: 'fa-regular fa-clock',
+      color: '#AB47BC',
+    },
+  ];
+
   chartData: ChartData<'bar'> = {
-    labels: ['Usuário A', 'Usuário B', 'Usuário C'],
+    labels: ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun'],
     datasets: [
       {
-        label: 'Acessos',
-        data: [5, 10, 7],
-        backgroundColor: ['#42A5F5', '#66BB6A', '#FFA726']
-      }
-    ]
+        label: 'Novos Usuários',
+        data: [150, 200, 180, 220, 300, 250],
+        backgroundColor: '#42A5F5',
+      },
+    ],
   };
 }

--- a/src/app/shared/metric-card/metric-card.component.css
+++ b/src/app/shared/metric-card/metric-card.component.css
@@ -1,0 +1,24 @@
+.metric-card {
+  text-align: center;
+}
+
+.metric-card i {
+  font-size: 2rem;
+}
+
+.metric-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.metric-value {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.metric-title {
+  font-size: 0.875rem;
+  color: var(--text-color);
+}

--- a/src/app/shared/metric-card/metric-card.component.html
+++ b/src/app/shared/metric-card/metric-card.component.html
@@ -1,0 +1,9 @@
+<p-card class="metric-card">
+  <ng-template pTemplate="header">
+    <i [class]="icon" [ngStyle]="{ color: color }"></i>
+  </ng-template>
+  <div class="metric-content">
+    <span class="metric-value">{{ value }}</span>
+    <span class="metric-title">{{ title }}</span>
+  </div>
+</p-card>

--- a/src/app/shared/metric-card/metric-card.component.ts
+++ b/src/app/shared/metric-card/metric-card.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-metric-card',
+  templateUrl: './metric-card.component.html',
+  styleUrls: ['./metric-card.component.css'],
+})
+export class MetricCardComponent {
+  @Input() icon = '';
+  @Input() title = '';
+  @Input() value: string | number = '';
+  @Input() color = '#3f51b5';
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -9,9 +9,10 @@ import { MenubarModule } from 'primeng/menubar';
 import { MessageModule } from 'primeng/message';
 import { ChartModule } from 'primeng/chart';
 import { FooterComponent } from './footer/footer.component';
+import { MetricCardComponent } from './metric-card/metric-card.component';
 
 @NgModule({
-  declarations: [FooterComponent],
+  declarations: [FooterComponent, MetricCardComponent],
   imports: [
     CommonModule,
     TableModule,
@@ -21,7 +22,7 @@ import { FooterComponent } from './footer/footer.component';
     CardModule,
     MenubarModule,
     MessageModule,
-    ChartModule
+    ChartModule,
   ],
   exports: [
     TableModule,
@@ -32,7 +33,8 @@ import { FooterComponent } from './footer/footer.component';
     MenubarModule,
     MessageModule,
     ChartModule,
-    FooterComponent
-  ]
+    FooterComponent,
+    MetricCardComponent,
+  ],
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary
- build metric card component for dashboard stats
- display metric cards and bar chart on home page

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm run format`
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*