### PR TITLE
Implement login menu toggle and add component tests

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -6,3 +6,13 @@
 .font-bold {
   font-weight: bold;
 }
+
+header {
+  display: block;
+}
+
+.content-wrapper {
+  padding: 1rem;
+  min-height: calc(100vh - 4rem);
+  display: block;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,9 +1,11 @@
-<p-menubar [model]="menuItems" class="p-mb-3">
-  <ng-template pTemplate="start">
-    <span class="font-bold">{{ startTemplate }}</span>
-  </ng-template>
-</p-menubar>
-<div class="content-wrapper">
+<header *ngIf="showMenu">
+  <p-menubar [model]="menuItems" class="p-mb-3" aria-label="Menu principal">
+    <ng-template pTemplate="start">
+      <span class="font-bold">{{ startTemplate }}</span>
+    </ng-template>
+  </p-menubar>
+</header>
+<main class="content-wrapper">
   <router-outlet></router-outlet>
-</div>
+</main>
 <app-footer></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, NavigationEnd } from '@angular/router';
 import { MenuItem } from 'primeng/api';
 import { AuthService } from './core/auth.service';
 
@@ -11,8 +11,15 @@ import { AuthService } from './core/auth.service';
 export class AppComponent implements OnInit {
   menuItems: MenuItem[] = [];
   startTemplate = 'MaxProcess';
+  showMenu = true;
 
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(private auth: AuthService, private router: Router) {
+    this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        this.showMenu = !event.urlAfterRedirects.includes('/auth/login');
+      }
+    });
+  }
 
   ngOnInit(): void {
     this.menuItems = [

--- a/src/app/pages/home/home.component.spec.ts
+++ b/src/app/pages/home/home.component.spec.ts
@@ -1,0 +1,29 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SharedModule } from '../../shared/shared.module';
+import { HomeComponent } from './home.component';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HomeComponent],
+      imports: [SharedModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain metrics', () => {
+    expect(component.metrics.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AuthService } from '../../core/auth.service';
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+  let auth: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(async () => {
+    auth = jasmine.createSpyObj('AuthService', ['login', 'getToken']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    await TestBed.configureTestingModule({
+      declarations: [LoginComponent],
+      imports: [FormsModule],
+      providers: [
+        { provide: AuthService, useValue: auth },
+        { provide: Router, useValue: router }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should login and navigate on success', () => {
+    auth.login.and.returnValue(of({}));
+    component.username = 'user';
+    component.password = 'pass';
+    component.login();
+    expect(auth.login).toHaveBeenCalledWith('user', 'pass');
+    expect(router.navigate).toHaveBeenCalledWith(['/home']);
+  });
+
+  it('should show error on failure', () => {
+    auth.login.and.returnValue(throwError(() => new Error()));
+    component.username = 'user';
+    component.password = 'pass';
+    component.login();
+    expect(component.error).toBe('Credenciais inválidas');
+  });
+});

--- a/src/app/pages/users/users.component.spec.ts
+++ b/src/app/pages/users/users.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { SharedModule } from '../../shared/shared.module';
+import { UserService } from '../../core/user.service';
+import { UsersComponent } from './users.component';
+
+describe('UsersComponent', () => {
+  let component: UsersComponent;
+  let fixture: ComponentFixture<UsersComponent>;
+  let service: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('UserService', ['getUsers']);
+    service.getUsers.and.returnValue(of([{ login: 't', email: 't@test.com' }]));
+
+    await TestBed.configureTestingModule({
+      declarations: [UsersComponent],
+      imports: [SharedModule],
+      providers: [{ provide: UserService, useValue: service }]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load users on init', () => {
+    expect(service.getUsers).toHaveBeenCalled();
+    expect(component.usuarios.length).toBe(1);
+  });
+});

--- a/src/app/shared/footer/footer.component.spec.ts
+++ b/src/app/shared/footer/footer.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FooterComponent } from './footer.component';
+
+describe('FooterComponent', () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FooterComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/metric-card/metric-card.component.spec.ts
+++ b/src/app/shared/metric-card/metric-card.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CardModule } from 'primeng/card';
+import { MetricCardComponent } from './metric-card.component';
+
+describe('MetricCardComponent', () => {
+  let component: MetricCardComponent;
+  let fixture: ComponentFixture<MetricCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MetricCardComponent],
+      imports: [CardModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MetricCardComponent);
+    component = fixture.componentInstance;
+    component.title = 'Test';
+    component.value = 1;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- hide navigation menu on login route
- enhance layout markup for accessibility
- add unit tests for login, home, users, footer and metric card components

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*