### PR TITLE
Add header and breadcrumb components

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,14 +1,6 @@
 
-:host ::ng-deep .p-menubar {
-  border-radius: 0;
-}
-
 .font-bold {
   font-weight: bold;
-}
-
-header {
-  display: block;
 }
 
 .content-wrapper {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,6 @@
-<header *ngIf="showMenu">
-  <p-menubar [model]="menuItems" class="p-mb-3" aria-label="Menu principal">
-    <ng-template pTemplate="start">
-      <span class="font-bold">{{ startTemplate }}</span>
-    </ng-template>
-  </p-menubar>
-</header>
+<app-header *ngIf="showMenu" [items]="menuItems" [title]="startTemplate"></app-header>
 <main class="content-wrapper">
+  <app-breadcrumbs></app-breadcrumbs>
   <router-outlet></router-outlet>
 </main>
 <app-footer></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -23,9 +23,9 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.menuItems = [
-      { label: 'Home', routerLink: '/home' },
-      { label: 'Usuários', routerLink: '/users' },
-      { label: 'Sair', command: () => this.logout() }
+      { label: 'Home', routerLink: '/home', icon: 'pi pi-home' },
+      { label: 'Usuários', routerLink: '/users', icon: 'pi pi-users' },
+      { label: 'Sair', command: () => this.logout(), icon: 'pi pi-sign-out' }
     ];
   }
 

--- a/src/app/pages/home/home.component.css
+++ b/src/app/pages/home/home.component.css
@@ -7,6 +7,11 @@
   min-height: calc(100vh - 4rem);
 }
 
+.home-wrapper h1 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
 .metrics-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -1,4 +1,5 @@
 <div class="home-wrapper">
+  <h1>Dashboard</h1>
   <div class="metrics-grid">
     <app-metric-card
       *ngFor="let metric of metrics"

--- a/src/app/pages/users/users.component.html
+++ b/src/app/pages/users/users.component.html
@@ -1,6 +1,7 @@
 
 <div class="users-container p-m-4">
-  <p-card header="Usuários">
+  <p-card header="Lista de Usuários">
+    <p class="p-mb-3">Confira abaixo os usuários cadastrados no sistema.</p>
     <p-table [value]="usuarios" responsiveLayout="scroll">
       <ng-template pTemplate="header">
         <tr>

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.css
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.css
@@ -1,0 +1,22 @@
+.breadcrumbs ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem;
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.breadcrumbs li::after {
+  content: '/';
+  margin-left: 0.5rem;
+}
+
+.breadcrumbs li:last-child::after {
+  content: '';
+}
+
+.breadcrumbs a {
+  text-decoration: none;
+  color: var(--primary-color);
+}

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.html
@@ -1,0 +1,8 @@
+<nav class="breadcrumbs" *ngIf="breadcrumbs.length">
+  <ul>
+    <li *ngFor="let bc of breadcrumbs; let last = last">
+      <a *ngIf="!last" [routerLink]="bc.url">{{ bc.label }}</a>
+      <span *ngIf="last">{{ bc.label }}</span>
+    </li>
+  </ul>
+</nav>

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
+
+interface Breadcrumb {
+  label: string;
+  url: string;
+}
+
+@Component({
+  selector: 'app-breadcrumbs',
+  templateUrl: './breadcrumbs.component.html',
+  styleUrls: ['./breadcrumbs.component.css']
+})
+export class BreadcrumbsComponent implements OnInit {
+  breadcrumbs: Breadcrumb[] = [];
+
+  constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(event => {
+        const url = (event as NavigationEnd).urlAfterRedirects;
+        const segments = url.split('/').filter(s => s);
+        let path = '';
+        this.breadcrumbs = segments.map(seg => {
+          path += `/${seg}`;
+          return { label: this.formatLabel(seg), url: path };
+        });
+      });
+  }
+
+  private formatLabel(segment: string): string {
+    switch (segment) {
+      case 'home':
+        return 'Home';
+      case 'users':
+        return 'Usuários';
+      case 'auth':
+        return 'Login';
+      default:
+        return segment.charAt(0).toUpperCase() + segment.slice(1);
+    }
+  }
+}

--- a/src/app/shared/header/header.component.css
+++ b/src/app/shared/header/header.component.css
@@ -1,0 +1,7 @@
+:host ::ng-deep .p-menubar {
+  border-radius: 0;
+}
+
+:host {
+  display: block;
+}

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -1,0 +1,5 @@
+<p-menubar [model]="items" class="p-mb-3" aria-label="Menu principal">
+  <ng-template pTemplate="start">
+    <span class="font-bold">{{ title }}</span>
+  </ng-template>
+</p-menubar>

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { MenuItem } from 'primeng/api';
+
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.css']
+})
+export class HeaderComponent {
+  @Input() items: MenuItem[] = [];
+  @Input() title = 'MaxProcess';
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -10,9 +10,16 @@ import { MessageModule } from 'primeng/message';
 import { ChartModule } from 'primeng/chart';
 import { FooterComponent } from './footer/footer.component';
 import { MetricCardComponent } from './metric-card/metric-card.component';
+import { HeaderComponent } from './header/header.component';
+import { BreadcrumbsComponent } from './breadcrumbs/breadcrumbs.component';
 
 @NgModule({
-  declarations: [FooterComponent, MetricCardComponent],
+  declarations: [
+    FooterComponent,
+    MetricCardComponent,
+    HeaderComponent,
+    BreadcrumbsComponent,
+  ],
   imports: [
     CommonModule,
     TableModule,
@@ -35,6 +42,8 @@ import { MetricCardComponent } from './metric-card/metric-card.component';
     ChartModule,
     FooterComponent,
     MetricCardComponent,
+    HeaderComponent,
+    BreadcrumbsComponent,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
## Summary
- create `HeaderComponent` with menu input
- create `BreadcrumbsComponent` to show navigation
- export the new components via `SharedModule`
- replace menubar markup with `<app-header>` and add `<app-breadcrumbs>`
- show icons in the menu items
- add basic content improvements on home and users pages

## Testing
- `npm test` *(fails: ng not found)*