### PR TITLE
Fix menu command call in header

### DIFF
--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -45,7 +45,7 @@
         <ng-template #command>
           <button
             class="mobile-menu-link"
-            (click)="item.command && item.command(); closeMobileMenu()"
+            (click)="item.command && item.command($event); closeMobileMenu()"
             role="menuitem"
           >
             <i [ngClass]="item.icon"></i>


### PR DESCRIPTION
## Summary
- fix mobile menu command execution to pass click event to `MenuItem.command`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*