### PR TITLE
Fix menu command click handling

### DIFF
--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -45,7 +45,7 @@
         <ng-template #command>
           <button
             class="mobile-menu-link"
-            (click)="item.command && item.command($event); closeMobileMenu()"
+            (click)="handleItemCommand(item, $event)"
             role="menuitem"
           >
             <i [ngClass]="item.icon"></i>

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -14,6 +14,11 @@ export class HeaderComponent {
 
   mobileMenuVisible = false;
 
+  handleItemCommand(item: MenuItem, event: Event): void {
+    item.command?.({ originalEvent: event, item });
+    this.closeMobileMenu();
+  }
+
   toggleMobileMenu() {
     this.mobileMenuVisible = !this.mobileMenuVisible;
   }


### PR DESCRIPTION
## Summary
- handle command events in header component using the expected `MenuItemCommandEvent`

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*