### PR TITLE
Fix /users page loading data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Futuramente é possível ampliar os testes, tratar renovação de token e armaze
 
 ## Mock da API
 
-Execute o servidor de mock para simular `/auth/login` e `/usuario`:
+Execute o servidor de mock para simular `/auth/login` e `/users`:
 
 ```bash
 npm run start:mock

--- a/cypress/e2e/users.cy.ts
+++ b/cypress/e2e/users.cy.ts
@@ -1,11 +1,11 @@
 describe('User list', () => {
   it('shows users table', () => {
-    cy.window().then(win => {
+    cy.window().then((win) => {
       win.localStorage.setItem('token', 'fake');
     });
-    cy.intercept('GET', '/usuario', [
+    cy.intercept('GET', '/users', [
       { login: 'alice', email: 'alice@example.com' },
-      { login: 'bob', email: 'bob@example.com' }
+      { login: 'bob', email: 'bob@example.com' },
     ]);
     cy.visit('/users');
     cy.get('table tbody tr').should('have.length', 2);

--- a/src/app/core/user.service.ts
+++ b/src/app/core/user.service.ts
@@ -6,7 +6,11 @@ import { environment } from '../../environments/environment';
 
 @Injectable()
 export class UserService {
-  private api = `${environment.apiBase}/usuario`;
+  /**
+   * Endpoint base para as operações de usuário. O servidor de mock
+   * expõe os dados em `/users`, portanto utilizamos esse caminho.
+   */
+  private api = `${environment.apiBase}/users`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- fix user service endpoint to `/users`
- update e2e test intercept to `/users`
- adjust README to reference `/users`

## Testing
- `npm test` *(fails: ng not found)*