### PR TITLE
Add missing tests and update deletion modal

### DIFF
--- a/cypress/e2e/full-flow.cy.ts
+++ b/cypress/e2e/full-flow.cy.ts
@@ -1,0 +1,21 @@
+describe('Fluxo completo de exclusão', () => {
+  it('faz login e exclui um usuário', () => {
+    cy.visit('/auth/login');
+    cy.get('#username').type('demo-gustavo@gmail.com');
+    cy.get('#password').type('123456');
+    cy.contains('button', 'Entrar').click();
+    cy.url().should('include', '/home');
+
+    cy.intercept('GET', '/users', [
+      { id: 1, name: 'Alice', email: 'a@example.com' },
+    ]).as('getUsers');
+    cy.intercept('DELETE', '/users/1', {}).as('delUser');
+
+    cy.contains('Usuários').click();
+    cy.wait('@getUsers');
+    cy.get('table tbody tr').should('have.length', 1);
+    cy.get('button[aria-label="Excluir"]').click();
+    cy.contains('button', 'Sim').click();
+    cy.wait('@delUser');
+  });
+});

--- a/src/app/core/user.service.spec.ts
+++ b/src/app/core/user.service.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { UserService } from './user.service';
+import { environment } from '../../environments/environment';
+import { User } from '../models/user';
+
+describe('UserService', () => {
+  let service: UserService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [UserService],
+    });
+    service = TestBed.inject(UserService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  it('should fetch users', () => {
+    const mock: User[] = [{ id: 1, email: 't@test.com' } as User];
+    service.getUsers().subscribe((users) => expect(users).toEqual(mock));
+    const req = http.expectOne(`${environment.apiBase}/users`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+  });
+
+  it('should delete user', () => {
+    service.deleteUser(1).subscribe();
+    const req = http.expectOne(`${environment.apiBase}/users/1`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush({});
+  });
+});

--- a/src/app/pages/users/user-list/user-list.component.ts
+++ b/src/app/pages/users/user-list/user-list.component.ts
@@ -81,8 +81,10 @@ export class UserListComponent implements OnInit, OnDestroy {
       message: `Tem certeza que deseja excluir ${user.name}?`,
       header: 'Confirmar Exclusão',
       icon: 'pi pi-exclamation-triangle',
-      acceptLabel: 'Sim, excluir',
+      acceptLabel: 'Sim',
       rejectLabel: 'Cancelar',
+      acceptIcon: '',
+      rejectIcon: '',
       defaultFocus: 'reject',
       accept: () => this.deleteUser(user),
     });


### PR DESCRIPTION
## Summary
- fix confirmation modal button text
- add unit tests for UserService
- cover login-to-delete user flow with Cypress

## Testing
- `npm test` *(fails: ng not found)*
- `npx cypress run` *(fails: could not reach npm registry)*