### PR TITLE
Improve header menu

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -15,7 +15,14 @@ export class AppComponent implements OnInit {
 
   private readonly appMenu: MenuItem[] = [
     { label: 'Home', routerLink: '/home', icon: 'pi pi-home' },
-    { label: 'Usuários', routerLink: '/users', icon: 'pi pi-users' },
+    {
+      label: 'Usuários',
+      icon: 'pi pi-users',
+      items: [
+        { label: 'Lista', routerLink: '/users', icon: 'pi pi-list' },
+        { label: 'Novo', routerLink: '/users/new', icon: 'pi pi-user-plus' }
+      ]
+    },
     { label: 'Sair', command: () => this.logout(), icon: 'pi pi-sign-out' }
   ];
 

--- a/src/app/shared/header/header.component.css
+++ b/src/app/shared/header/header.component.css
@@ -3,6 +3,12 @@
   font-family: var(--font-family);
 }
 
+.header-nav {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
 :host ::ng-deep .app-menubar {
   background: var(--primary-color);
   color: #fff;
@@ -18,7 +24,7 @@
   color: #fff;
   padding: 0.75rem 1rem;
   font-weight: 500;
-  transition: background-color 0.3s;
+  transition: background-color 0.3s, border-color 0.3s;
 }
 
 :host ::ng-deep .app-menubar .p-menuitem-link:hover,
@@ -26,6 +32,7 @@
 :host ::ng-deep .app-menubar .p-menuitem-link.p-highlight {
   background: var(--primary-color-dark);
   color: #fff;
+  border-bottom: 2px solid #fff;
 }
 
 .brand {
@@ -49,6 +56,13 @@
   gap: 0.5rem;
 }
 
+.avatar-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
 .username {
   font-weight: 500;
 }
@@ -69,7 +83,7 @@
   background: var(--primary-color-dark);
 }
 
-.mobile-sidebar ::ng-deep .mobile-menu-link {
+.mobile-sidebar ::ng-deep .mobile-panel-menu .p-menuitem-link {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -81,8 +95,8 @@
   transition: background-color 0.3s;
 }
 
-.mobile-sidebar ::ng-deep .mobile-menu-link:hover,
-.mobile-sidebar ::ng-deep .mobile-menu-link:focus {
+.mobile-sidebar ::ng-deep .mobile-panel-menu .p-menuitem-link:hover,
+.mobile-sidebar ::ng-deep .mobile-panel-menu .p-menuitem-link:focus {
   background: rgba(0, 0, 0, 0.05);
 }
 

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -1,5 +1,5 @@
 <nav class="header-nav" aria-label="Menu principal" role="navigation">
-  <p-menubar [model]="items" class="app-menubar">
+  <p-menubar [model]="items" class="app-menubar" role="menubar" aria-label="Menu principal">
     <ng-template pTemplate="start">
       <div class="brand" role="img" aria-label="Logo">
         <i class="pi pi-briefcase logo-icon"></i>
@@ -8,12 +8,18 @@
     </ng-template>
     <ng-template pTemplate="end">
       <div class="profile">
-        <i class="pi pi-user avatar-icon"></i>
+        <ng-container *ngIf="userAvatar; else defaultAvatar">
+          <img [src]="userAvatar" alt="Avatar" class="avatar-icon" />
+        </ng-container>
+        <ng-template #defaultAvatar>
+          <i class="pi pi-user avatar-icon"></i>
+        </ng-template>
         <span class="username">{{ userName }}</span>
         <button
           type="button"
           class="menu-toggle p-link"
           (click)="toggleMobileMenu()"
+          (keydown.enter)="toggleMobileMenu()"
           [attr.aria-expanded]="mobileMenuVisible"
           aria-label="Abrir menu"
         >
@@ -29,30 +35,8 @@
     [baseZIndex]="10000"
     class="mobile-sidebar"
     aria-label="Menu móvel"
+    ariaCloseLabel="Fechar menu"
   >
-    <ul class="mobile-menu" role="menu">
-      <li *ngFor="let item of items" role="none">
-        <a
-          *ngIf="item.routerLink; else command"
-          [routerLink]="item.routerLink"
-          class="mobile-menu-link"
-          role="menuitem"
-          (click)="closeMobileMenu()"
-        >
-          <i [ngClass]="item.icon"></i>
-          <span>{{ item.label }}</span>
-        </a>
-        <ng-template #command>
-          <button
-            class="mobile-menu-link"
-            (click)="handleItemCommand(item, $event)"
-            role="menuitem"
-          >
-            <i [ngClass]="item.icon"></i>
-            <span>{{ item.label }}</span>
-          </button>
-        </ng-template>
-      </li>
-    </ul>
+    <p-panelMenu [model]="items" class="mobile-panel-menu"></p-panelMenu>
   </p-sidebar>
 </nav>

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -10,7 +10,7 @@ export class HeaderComponent {
   @Input() items: MenuItem[] = [];
   @Input() title = 'MaxProcess';
   @Input() userName = 'Gustavo Vasconcelos';
-  @Input() userAvatar = 'assets/avatar.png';
+  @Input() userAvatar = '';
 
   mobileMenuVisible = false;
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -8,6 +8,7 @@ import { CardModule } from 'primeng/card';
 import { MenubarModule } from 'primeng/menubar';
 import { MenuModule } from 'primeng/menu';
 import { SidebarModule } from 'primeng/sidebar';
+import { PanelMenuModule } from 'primeng/panelmenu';
 import { MessageModule } from 'primeng/message';
 import { ChartModule } from 'primeng/chart';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -35,6 +36,7 @@ import { BreadcrumbsComponent } from './breadcrumbs/breadcrumbs.component';
     MenubarModule,
     MenuModule,
     SidebarModule,
+    PanelMenuModule,
     MessageModule,
     ChartModule,
     ConfirmDialogModule,
@@ -50,6 +52,7 @@ import { BreadcrumbsComponent } from './breadcrumbs/breadcrumbs.component';
     MenubarModule,
     MenuModule,
     SidebarModule,
+    PanelMenuModule,
     MessageModule,
     ChartModule,
     ConfirmDialogModule,


### PR DESCRIPTION
## Summary
- upgrade header HTML with avatar logic and sidebar panel menu
- style mobile menu panel items
- make avatar optional via input
- import PanelMenuModule in shared module
- remove placeholder avatar image

## Testing
- `npm test --silent` *(fails: ng not found)*