### PR TITLE
Ajusta layout do header e listagem de usuários

### DIFF
--- a/src/app/pages/users/user-list/user-list.component.html
+++ b/src/app/pages/users/user-list/user-list.component.html
@@ -43,8 +43,6 @@
     dataKey="id"
     responsiveLayout="stack"
     breakpoint="768px"
-    [scrollable]="true"
-    scrollHeight="400px"
     aria-label="Tabela de usuários"
   >
     <ng-template pTemplate="caption">
@@ -59,9 +57,7 @@
     <ng-template pTemplate="header">
       <tr>
         <th pSortableColumn="id">ID <p-sortIcon field="id"></p-sortIcon></th>
-        <th>Avatar</th>
-        <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
-        <th pSortableColumn="email">E-mail <p-sortIcon field="email"></p-sortIcon></th>
+        <th>Usuário</th>
         <th pSortableColumn="profile">Perfil <p-sortIcon field="profile"></p-sortIcon></th>
         <th>Ações</th>
       </tr>
@@ -70,10 +66,14 @@
       <tr>
         <td>{{ user.id }}</td>
         <td>
-          <img [src]="user.avatarUrl" class="avatar" alt="{{ user.name }}" />
+          <div class="user-card">
+            <img [src]="user.avatarUrl" class="avatar" alt="{{ user.name }}" />
+            <div class="info">
+              <div class="name">{{ user.name }}</div>
+              <small class="email">{{ user.email }}</small>
+            </div>
+          </div>
         </td>
-        <td>{{ user.name }}</td>
-        <td>{{ user.email }}</td>
         <td>{{ user.profile }}</td>
         <td class="actions">
           <button
@@ -97,7 +97,7 @@
     </ng-template>
     <ng-template pTemplate="emptymessage">
       <tr>
-        <td [attr.colspan]="6">Nenhum usuário encontrado</td>
+        <td [attr.colspan]="4">Nenhum usuário encontrado</td>
       </tr>
     </ng-template>
   </p-table>

--- a/src/app/pages/users/user-list/user-list.component.scss
+++ b/src/app/pages/users/user-list/user-list.component.scss
@@ -55,10 +55,21 @@
 }
 
 .avatar {
-  width: 2rem;
-  height: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
   object-fit: cover;
+}
+
+.user-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.user-card .info {
+  display: flex;
+  flex-direction: column;
 }
 
 :host ::ng-deep .custom-confirm .p-confirm-dialog {
@@ -110,9 +121,17 @@
 @media (max-width: 768px) {
   .filters {
     flex-direction: column;
-    align-items: stretch;
+    gap: 1rem;
   }
   .clear-btn {
-    align-self: flex-end;
+    width: 100%;
+  }
+  .filters .p-input-icon-left,
+  .filters input {
+    width: 100%;
+  }
+  :host ::ng-deep .p-datatable-tbody > tr > td {
+    display: block;
+    padding: 1rem;
   }
 }

--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -37,6 +37,10 @@
       </a>
     </ng-template>
     <ng-template pTemplate="end">
+      <div class="user-info">
+        <div class="username">{{ userName }}</div>
+        <small class="email">{{ userEmail }}</small>
+      </div>
       <button
         *ngIf="auth.isLoggedIn()"
         pButton
@@ -49,10 +53,6 @@
     </ng-template>
   </p-menubar>
 
-  <div class="user-info" *ngIf="showMenu">
-    <span class="username">{{ userName }}</span>
-    <small class="email">{{ userEmail }}</small>
-  </div>
 
   <p-sidebar
     *ngIf="showMenu"

--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -95,13 +95,11 @@
 }
 
 .user-info {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
   color: var(--text-color);
-  text-align: center;
-  pointer-events: none;
 }
 
 .avatar-icon {


### PR DESCRIPTION
## Summary
- exibe nome e email no menubar do header e mantem o botão sair
- ajusta CSS do header para alinhar informações do usuário
- melhora responsividade da lista de usuários e remove scroll
- mostra avatar, nome e email em um card
- estilos para filtros e tabela em mobile

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*