### PR TITLE
Add mobile hamburger menu

### DIFF
--- a/src/app/shared/header/header.component.html
+++ b/src/app/shared/header/header.component.html
@@ -14,22 +14,38 @@
       <div class="user-email">{{ userEmail }}</div>
     </div>
     <button class="logout-btn" *ngIf="!isMobile" (click)="logout()">Sair</button>
-    <button class="burger" *ngIf="isMobile" (click)="toggleMenu()" aria-label="Menu">
+    <button
+      class="burger"
+      *ngIf="isMobile"
+      (click)="toggleMenu()"
+      aria-label="Menu"
+      [attr.aria-expanded]="isMenuOpen"
+      aria-controls="mobile-menu"
+    >
       <i class="fa fa-bars"></i>
     </button>
   </div>
-  <div class="mobile-menu" *ngIf="isMobile" [class.open]="isMenuOpen">
-    <ul class="nav-list">
-      <li *ngFor="let item of navItems" (click)="navigate(item.path)" routerLinkActive="active">
-        <i [class]="item.icon"></i>
-        <span>{{ item.label }}</span>
-      </li>
-    </ul>
-    <div class="user-section">
-      <div class="user-name">{{ userName }}</div>
-      <div class="user-email">{{ userEmail }}</div>
-      <button class="logout-btn" (click)="logout()">Sair</button>
-    </div>
+  <div class="mobile-menu" *ngIf="isMobile">
+    <div class="backdrop" [class.open]="isMenuOpen" (click)="closeMenu()"></div>
+    <nav
+      class="panel"
+      id="mobile-menu"
+      [class.open]="isMenuOpen"
+      [attr.aria-hidden]="!isMenuOpen"
+    >
+      <ul class="nav-list">
+        <li *ngFor="let item of navItems" (click)="navigate(item.path)" routerLinkActive="active">
+          <i [class]="item.icon"></i>
+          <span>{{ item.label }}</span>
+        </li>
+      </ul>
+      <hr class="divider" />
+      <div class="user-section">
+        <div class="user-name">{{ userName }}</div>
+        <div class="user-email">{{ userEmail }}</div>
+        <button class="logout-btn" (click)="logout()">Sair</button>
+      </div>
+    </nav>
   </div>
 </header>
 

--- a/src/app/shared/header/header.component.scss
+++ b/src/app/shared/header/header.component.scss
@@ -106,16 +106,51 @@
 
     .mobile-menu {
       display: block;
+    }
+  }
+
+  .mobile-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1001;
+    pointer-events: none;
+
+    .backdrop {
       position: absolute;
-      top: 4rem;
+      top: 0;
       left: 0;
       width: 100%;
-      background: #3f51b5;
-      transform: translateY(-100%);
-      transition: transform 0.3s ease;
+      height: 100%;
+      background: rgba(0, 0, 0, 0.5);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      pointer-events: none;
 
       &.open {
-        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+      }
+    }
+
+    .panel {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 16rem;
+      max-width: 80%;
+      height: 100%;
+      background: #3f51b5;
+      transform: translateX(-100%);
+      transition: transform 0.3s ease;
+      display: flex;
+      flex-direction: column;
+      padding-top: 4rem;
+
+      &.open {
+        transform: translateX(0);
       }
 
       .nav-list {
@@ -129,9 +164,15 @@
         }
       }
 
-      .user-section {
-        padding: 1rem;
+      .divider {
+        margin: 0;
+        border: none;
         border-top: 1px solid rgba(255, 255, 255, 0.2);
+      }
+
+      .user-section {
+        margin-top: auto;
+        padding: 1rem;
         text-align: center;
       }
     }

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -45,8 +45,19 @@ export class HeaderComponent implements OnInit {
     }
   }
 
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.isMobile) {
+      this.isMenuOpen = false;
+    }
+  }
+
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
+  }
+
+  closeMenu(): void {
+    this.isMenuOpen = false;
   }
 
   navigate(path: string): void {
@@ -59,6 +70,9 @@ export class HeaderComponent implements OnInit {
   logout(): void {
     this.auth.logout();
     this.router.navigate(['/auth/login']);
+    if (this.isMobile) {
+      this.isMenuOpen = false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add ARIA-driven hamburger menu for mobile
- slide-in mobile nav panel with user block
- close menu on escape key and after logout

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*