### PR TITLE
Fix p-table recognition

### DIFF
--- a/src/app/modules/users/users.module.ts
+++ b/src/app/modules/users/users.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { UserFilterComponent } from './components/user-filter/user-filter.component';
 import { UserTableComponent } from './components/user-table/user-table.component';
 import { UserListContainerComponent } from './containers/user-list-container/user-list-container.component';
+import { UserListComponent } from '../../pages/users/user-list/user-list.component';
 import { FormsModule } from '@angular/forms';
 import { SharedModule } from '../../shared/shared.module';
 import { UsersRoutingModule } from './users-routing.module';
@@ -18,6 +19,7 @@ import { SkeletonModule } from 'primeng/skeleton';
     UserFilterComponent,
     UserTableComponent,
     UserListContainerComponent,
+    UserListComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
## Summary
- declare `UserListComponent` inside `UsersModule`
- import `UserListComponent` path so that PrimeNG table works

## Testing
- `npm test` *(fails: ng not found)*