### PR TITLE
Fix header visibility on login page

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<app-header></app-header>
+<app-header *ngIf="showHeader"></app-header>
 <main class="content-wrapper">
   <app-breadcrumbs *ngIf="showBreadcrumbs"></app-breadcrumbs>
   <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,12 +24,15 @@ export class AppComponent {
 
   startTemplate = 'MaxProcess';
   showBreadcrumbs = true;
+  showHeader = true;
 
   constructor(private auth: AuthService, private router: Router) {
     this.router.events.subscribe(e => {
       if (e instanceof NavigationEnd) {
         const url = e.urlAfterRedirects;
-        this.showBreadcrumbs = !url.includes('/auth/login') && !url.includes('/auth/forgot-password');
+        const isAuthPage = url.includes('/auth/login') || url.includes('/auth/forgot-password');
+        this.showBreadcrumbs = !isAuthPage;
+        this.showHeader = !isAuthPage;
       }
     });
   }


### PR DESCRIPTION
## Summary
- hide header on login and forgot-password pages

## Testing
- `npm test` *(fails: ng not found)*