### PR TITLE
Add missing Angular component tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, NavigationEnd } from '@angular/router';
+import { Subject } from 'rxjs';
+import { AppComponent } from './app.component';
+import { AuthService } from './core/auth.service';
+
+describe('AppComponent', () => {
+  let component: AppComponent;
+  let fixture: ComponentFixture<AppComponent>;
+  let routerEvents$: Subject<any>;
+  let auth: jasmine.SpyObj<AuthService>;
+
+  beforeEach(async () => {
+    routerEvents$ = new Subject();
+    auth = jasmine.createSpyObj('AuthService', ['logout']);
+    await TestBed.configureTestingModule({
+      declarations: [AppComponent],
+      providers: [
+        { provide: Router, useValue: { events: routerEvents$, navigate: () => {} } },
+        { provide: AuthService, useValue: auth }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AppComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should hide header on auth pages', () => {
+    routerEvents$.next(new NavigationEnd(1, '/auth/login', '/auth/login'));
+    expect(component.showHeader).toBeFalse();
+  });
+
+  it('should call logout and navigate', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+    component.logout();
+    expect(auth.logout).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+  });
+});

--- a/src/app/modules/auth/components/forgot-password-link/forgot-password-link.component.spec.ts
+++ b/src/app/modules/auth/components/forgot-password-link/forgot-password-link.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ForgotPasswordLinkComponent } from './forgot-password-link.component';
+
+describe('ForgotPasswordLinkComponent', () => {
+  let component: ForgotPasswordLinkComponent;
+  let fixture: ComponentFixture<ForgotPasswordLinkComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ForgotPasswordLinkComponent],
+      imports: [RouterTestingModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ForgotPasswordLinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/auth/components/login-form/login-form.component.spec.ts
+++ b/src/app/modules/auth/components/login-form/login-form.component.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { LoginFormComponent } from './login-form.component';
+
+describe('LoginFormComponent', () => {
+  let component: LoginFormComponent;
+  let fixture: ComponentFixture<LoginFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LoginFormComponent],
+      imports: [FormsModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoginFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit login data', () => {
+    spyOn(component.login, 'emit');
+    component.username = 'user';
+    component.password = 'pass';
+    component.remember = true;
+    component.submit();
+    expect(component.login.emit).toHaveBeenCalledWith({ username: 'user', password: 'pass', remember: true });
+  });
+});

--- a/src/app/modules/auth/components/social-login-buttons/social-login-buttons.component.spec.ts
+++ b/src/app/modules/auth/components/social-login-buttons/social-login-buttons.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SocialLoginButtonsComponent } from './social-login-buttons.component';
+
+describe('SocialLoginButtonsComponent', () => {
+  let component: SocialLoginButtonsComponent;
+  let fixture: ComponentFixture<SocialLoginButtonsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SocialLoginButtonsComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SocialLoginButtonsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/auth/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/modules/auth/forgot-password/forgot-password.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { ForgotPasswordComponent } from './forgot-password.component';
+
+describe('ForgotPasswordComponent', () => {
+  let component: ForgotPasswordComponent;
+  let fixture: ComponentFixture<ForgotPasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ForgotPasswordComponent],
+      imports: [FormsModule],
+      providers: [MessageService]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ForgotPasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should reset email after send', fakeAsync(() => {
+    component.email = 'test@test.com';
+    component.send();
+    tick(1000);
+    expect(component.email).toBe('');
+    expect(component.loading).toBeFalse();
+  }));
+});

--- a/src/app/modules/users/components/user-filter/user-filter.component.spec.ts
+++ b/src/app/modules/users/components/user-filter/user-filter.component.spec.ts
@@ -1,0 +1,43 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { UserFilterComponent } from './user-filter.component';
+
+describe('UserFilterComponent', () => {
+  let component: UserFilterComponent;
+  let fixture: ComponentFixture<UserFilterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [UserFilterComponent],
+      imports: [FormsModule]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit filter values', () => {
+    spyOn(component.filterChange, 'emit');
+    component.filterName = 't';
+    component.filterEmail = 'e';
+    component.apply();
+    expect(component.filterChange.emit).toHaveBeenCalledWith({ name: 't', email: 'e' });
+  });
+
+  it('should clear filters', () => {
+    spyOn(component.clear, 'emit');
+    component.filterName = 't';
+    component.filterEmail = 'e';
+    component.clearFilters();
+    expect(component.filterName).toBe('');
+    expect(component.filterEmail).toBe('');
+    expect(component.clear.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/modules/users/components/user-table/user-table.component.spec.ts
+++ b/src/app/modules/users/components/user-table/user-table.component.spec.ts
@@ -1,0 +1,38 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UserTableComponent } from './user-table.component';
+import { User } from 'src/app/models/user';
+
+describe('UserTableComponent', () => {
+  let component: UserTableComponent;
+  let fixture: ComponentFixture<UserTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [UserTableComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit edit event', () => {
+    spyOn(component.edit, 'emit');
+    const user = { id: 1 } as User;
+    component.edit.emit(user);
+    expect(component.edit.emit).toHaveBeenCalledWith(user);
+  });
+
+  it('should emit delete event', () => {
+    spyOn(component.delete, 'emit');
+    const user = { id: 2 } as User;
+    component.delete.emit(user);
+    expect(component.delete.emit).toHaveBeenCalledWith(user);
+  });
+});

--- a/src/app/modules/users/containers/user-list-container/user-list-container.component.spec.ts
+++ b/src/app/modules/users/containers/user-list-container/user-list-container.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { UserService } from 'src/app/core/user.service';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { UserListContainerComponent } from './user-list-container.component';
+
+describe('UserListContainerComponent', () => {
+  let component: UserListContainerComponent;
+  let fixture: ComponentFixture<UserListContainerComponent>;
+  let service: jasmine.SpyObj<UserService>;
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj('UserService', ['getUsers', 'deleteUser']);
+    service.getUsers.and.returnValue(of([]));
+    service.deleteUser.and.returnValue(of(null));
+
+    await TestBed.configureTestingModule({
+      declarations: [UserListContainerComponent],
+      providers: [
+        { provide: UserService, useValue: service },
+        ConfirmationService,
+        MessageService
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserListContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load users on init', () => {
+    expect(service.getUsers).toHaveBeenCalled();
+  });
+
+  it('should filter users', () => {
+    component.users = [
+      { id: 1, name: 'Test', email: 'a@test.com' } as any,
+      { id: 2, name: 'Foo', email: 'b@bar.com' } as any
+    ];
+    component.onFilter({ name: 't', email: '' });
+    expect(component.filteredUsers.length).toBe(1);
+  });
+});

--- a/src/app/shared/breadcrumbs/breadcrumbs.component.spec.ts
+++ b/src/app/shared/breadcrumbs/breadcrumbs.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, NavigationEnd } from '@angular/router';
+import { Subject } from 'rxjs';
+import { BreadcrumbsComponent } from './breadcrumbs.component';
+
+describe('BreadcrumbsComponent', () => {
+  let component: BreadcrumbsComponent;
+  let fixture: ComponentFixture<BreadcrumbsComponent>;
+  let events$: Subject<any>;
+
+  beforeEach(async () => {
+    events$ = new Subject();
+    await TestBed.configureTestingModule({
+      declarations: [BreadcrumbsComponent],
+      providers: [
+        { provide: Router, useValue: { events: events$ } }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BreadcrumbsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should build breadcrumbs on navigation', () => {
+    events$.next(new NavigationEnd(1, '/users', '/users'));
+    expect(component.breadcrumbs.length).toBe(1);
+    expect(component.breadcrumbs[0].label).toBe('Usuários');
+  });
+});

--- a/src/app/shared/header/header.component.spec.ts
+++ b/src/app/shared/header/header.component.spec.ts
@@ -1,0 +1,54 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AuthService } from '../../core/auth.service';
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+  let router: jasmine.SpyObj<Router>;
+  let auth: jasmine.SpyObj<AuthService>;
+
+  beforeEach(async () => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    auth = jasmine.createSpyObj('AuthService', ['getUserName', 'getUserEmail', 'logout']);
+    await TestBed.configureTestingModule({
+      declarations: [HeaderComponent],
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: AuthService, useValue: auth }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should toggle menu', () => {
+    component.isMenuOpen = false;
+    component.toggleMenu();
+    expect(component.isMenuOpen).toBeTrue();
+  });
+
+  it('should close menu on navigate when mobile', () => {
+    component.isMobile = true;
+    component.isMenuOpen = true;
+    component.navigate('/home');
+    expect(router.navigate).toHaveBeenCalledWith(['/home']);
+    expect(component.isMenuOpen).toBeFalse();
+  });
+
+  it('should call logout and navigate', () => {
+    component.isMobile = false;
+    component.logout();
+    expect(auth.logout).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+  });
+});

--- a/src/app/shared/nav-menu/nav-menu.component.spec.ts
+++ b/src/app/shared/nav-menu/nav-menu.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MenuItem } from 'primeng/api';
+import { NavMenuComponent } from './nav-menu.component';
+
+describe('NavMenuComponent', () => {
+  let component: NavMenuComponent;
+  let fixture: ComponentFixture<NavMenuComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NavMenuComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NavMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit on item command', () => {
+    const item: MenuItem = { label: 'Home' };
+    spyOn(component.itemSelect, 'emit');
+    const event = new Event('click');
+    component.onCommand(item, event);
+    expect(component.itemSelect.emit).toHaveBeenCalledWith(item);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for app component and shared components
- test login form and forgot password flows
- cover user list container and auxiliary components

## Testing
- `npm test --silent` *(fails: ng not found)*