### PR TITLE
Prefill login username from storage

### DIFF
--- a/src/app/modules/auth/components/login-form/login-form.component.ts
+++ b/src/app/modules/auth/components/login-form/login-form.component.ts
@@ -13,7 +13,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LoginFormComponent {
-  username = '';
+  @Input() username = '';
   password = '';
   remember = false;
   @Input() error = '';

--- a/src/app/pages/login/login.component.html
+++ b/src/app/pages/login/login.component.html
@@ -8,7 +8,12 @@
       </div>
     </header>
     <div class="login-body">
-      <app-login-form (login)="login($event)" [error]="error" [loading]="loading"></app-login-form>
+      <app-login-form
+        (login)="login($event)"
+        [error]="error"
+        [loading]="loading"
+        [username]="rememberedUsername"
+      ></app-login-form>
     </div>
   </div>
 </div>

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -1,8 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { of, throwError } from 'rxjs';
 import { AuthService } from '../../core/auth.service';
+import { LoginFormComponent } from '../../modules/auth/components/login-form/login-form.component';
 import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {
@@ -15,12 +18,13 @@ describe('LoginComponent', () => {
     auth = jasmine.createSpyObj('AuthService', ['login', 'getToken']);
     router = jasmine.createSpyObj('Router', ['navigate']);
     await TestBed.configureTestingModule({
-      declarations: [LoginComponent],
+      declarations: [LoginComponent, LoginFormComponent],
       imports: [FormsModule],
       providers: [
         { provide: AuthService, useValue: auth },
         { provide: Router, useValue: router },
       ],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   });
 
@@ -36,18 +40,26 @@ describe('LoginComponent', () => {
 
   it('should login and navigate on success', () => {
     auth.login.and.returnValue(of({}));
-    component.username = 'user';
-    component.password = 'pass';
-    component.login();
+    component.login({ username: 'user', password: 'pass', remember: true });
     expect(auth.login).toHaveBeenCalledWith('user', 'pass');
     expect(router.navigate).toHaveBeenCalledWith(['/home']);
   });
 
   it('should show error on failure', () => {
     auth.login.and.returnValue(throwError(() => new Error()));
-    component.username = 'user';
-    component.password = 'pass';
-    component.login();
+    component.login({ username: 'user', password: 'pass', remember: false });
     expect(component.error).toBe('Credenciais inválidas');
+  });
+
+  it('should pre-fill stored username', () => {
+    localStorage.setItem('rememberedUsername', 'stored');
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    const form = fixture.debugElement.query(
+      By.directive(LoginFormComponent)
+    ).componentInstance as LoginFormComponent;
+    expect(form.username).toBe('stored');
+    localStorage.removeItem('rememberedUsername');
   });
 });

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -17,6 +17,7 @@ import { Subscription } from 'rxjs';
 export class LoginComponent implements OnInit, OnDestroy {
   error = '';
   loading = false;
+  rememberedUsername = '';
   private subscription!: Subscription;
 
   constructor(
@@ -34,7 +35,8 @@ export class LoginComponent implements OnInit, OnDestroy {
       return;
     }
 
-    // lembrado via localStorage é passado para o componente filho
+    this.rememberedUsername =
+      localStorage.getItem('rememberedUsername') ?? '';
   }
 
   /**


### PR DESCRIPTION
## Summary
- read `rememberedUsername` on init and send it to login form
- expose `username` as `@Input` in `LoginFormComponent`
- update login page template to bind stored username
- rewrite unit tests for LoginComponent to cover this behavior

## Testing
- `npm test` *(fails: ng not found)*