### PR TITLE
Add token expiry validation method

### DIFF
--- a/src/app/core/auth.guard.spec.ts
+++ b/src/app/core/auth.guard.spec.ts
@@ -8,14 +8,18 @@ describe('AuthGuard', () => {
   let router: jasmine.SpyObj<Router>;
 
   beforeEach(() => {
-    authService = jasmine.createSpyObj('AuthService', ['getToken', 'logout']);
+    authService = jasmine.createSpyObj('AuthService', [
+      'getToken',
+      'logout',
+      'isTokenExpired',
+    ]);
     router = jasmine.createSpyObj('Router', ['navigate']);
     guard = new AuthGuard(authService, router);
   });
 
   it('should allow activation with valid token', () => {
     authService.getToken.and.returnValue('header.payload.signature');
-    spyOn<any>(guard as any, 'tokenExpired').and.returnValue(false);
+    authService.isTokenExpired.and.returnValue(false);
     expect(guard.canActivate()).toBeTrue();
   });
 

--- a/src/app/core/auth.guard.ts
+++ b/src/app/core/auth.guard.ts
@@ -2,29 +2,13 @@ import { Injectable } from '@angular/core';
 import { CanActivate, Router } from '@angular/router';
 import { AuthService } from './auth.service';
 
-interface JwtPayload {
-  exp?: number;
-}
-
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(private auth: AuthService, private router: Router) {}
 
-  private tokenExpired(token: string): boolean {
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1])) as JwtPayload;
-      if (!payload.exp) {
-        return false;
-      }
-      return payload.exp * 1000 < Date.now();
-    } catch {
-      return false;
-    }
-  }
-
   canActivate(): boolean {
     const token = this.auth.getToken();
-    if (!token || this.tokenExpired(token)) {
+    if (!token || this.auth.isTokenExpired(token)) {
       this.router.navigate(['/auth/login']);
       return false;
     }

--- a/src/app/core/auth.service.spec.ts
+++ b/src/app/core/auth.service.spec.ts
@@ -35,4 +35,16 @@ describe('AuthService', () => {
     localStorage.setItem('token', 'abc');
     expect(service.getToken()).toBe('abc');
   });
+
+  it('should detect expired token', () => {
+    const past = Math.floor(Date.now() / 1000) - 60;
+    const token = `h.${btoa(JSON.stringify({ exp: past }))}.s`;
+    expect(service.isTokenExpired(token)).toBeTrue();
+  });
+
+  it('should detect valid token', () => {
+    const future = Math.floor(Date.now() / 1000) + 60;
+    const token = `h.${btoa(JSON.stringify({ exp: future }))}.s`;
+    expect(service.isTokenExpired(token)).toBeFalse();
+  });
 });

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -52,4 +52,20 @@ export class AuthService {
   getUserEmail(): string | null {
     return localStorage.getItem('userEmail');
   }
+
+  /**
+   * Checks if a given JWT token is expired based on the `exp` claim.
+   * If the token does not contain an expiration, it is considered valid.
+   */
+  isTokenExpired(token: string): boolean {
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1])) as { exp?: number };
+      if (!payload.exp) {
+        return false;
+      }
+      return payload.exp * 1000 < Date.now();
+    } catch {
+      return false;
+    }
+  }
 }

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -15,7 +15,11 @@ describe('LoginComponent', () => {
   let router: jasmine.SpyObj<Router>;
 
   beforeEach(async () => {
-    auth = jasmine.createSpyObj('AuthService', ['login', 'getToken']);
+    auth = jasmine.createSpyObj('AuthService', [
+      'login',
+      'getToken',
+      'isTokenExpired',
+    ]);
     router = jasmine.createSpyObj('Router', ['navigate']);
     await TestBed.configureTestingModule({
       declarations: [LoginComponent, LoginFormComponent],

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -30,7 +30,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     // redirecionamos diretamente para a home para evitar
     // exibir novamente o formulário de login.
     const token = this.auth.getToken();
-    if (token && !this.tokenExpired(token)) {
+    if (token && !this.auth.isTokenExpired(token)) {
       this.router.navigate(['/home']);
       return;
     }
@@ -39,20 +39,6 @@ export class LoginComponent implements OnInit, OnDestroy {
       localStorage.getItem('rememberedUsername') ?? '';
   }
 
-  /**
-   * Verifica se o token JWT está expirado.
-   */
-  private tokenExpired(token: string): boolean {
-    try {
-      const payload = JSON.parse(atob(token.split('.')[1])) as { exp?: number };
-      if (!payload.exp) {
-        return false;
-      }
-      return payload.exp * 1000 < Date.now();
-    } catch {
-      return false;
-    }
-  }
 
   login(credentials: {
     username: string;


### PR DESCRIPTION
## Summary
- add `isTokenExpired` method to `AuthService`
- use the new helper in `LoginComponent` and `AuthGuard`
- adjust specs to rely on the new method and cover token expiration

## Testing
- `npm test` *(fails: ng not found)*