### PR TITLE
Add email validation to login

### DIFF
--- a/src/app/modules/auth/components/login-form/login-form.component.html
+++ b/src/app/modules/auth/components/login-form/login-form.component.html
@@ -4,7 +4,10 @@
     <i class="fa-solid fa-user"></i>
     <input
       id="username"
+      type="email"
       [(ngModel)]="username"
+      #email="ngModel"
+      required
       pInputText
       class="w-full"
       placeholder="Usuário"
@@ -12,6 +15,9 @@
       autocomplete="username"
     />
   </span>
+  <div *ngIf="email.invalid && email.touched" class="error-message">
+    E-mail inválido
+  </div>
 </div>
 <div class="login-field">
   <span class="p-input-icon-left w-full">

--- a/src/app/pages/login/login.component.spec.ts
+++ b/src/app/pages/login/login.component.spec.ts
@@ -55,6 +55,11 @@ describe('LoginComponent', () => {
     expect(component.error).toBe('Credenciais inválidas');
   });
 
+  it('should show email invalid error', () => {
+    component.login({ username: 'invalid', password: 'pass', remember: false });
+    expect(component.error).toBe('E-mail inválido');
+  });
+
   it('should pre-fill stored username', () => {
     localStorage.setItem('rememberedUsername', 'stored');
     fixture = TestBed.createComponent(LoginComponent);

--- a/src/app/pages/login/login.component.ts
+++ b/src/app/pages/login/login.component.ts
@@ -41,8 +41,13 @@ export class LoginComponent implements OnInit, OnDestroy {
     remember: boolean;
   }): void {
     this.error = '';
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!credentials.username.trim() || !credentials.password.trim()) {
       this.error = 'Informe usuário e senha';
+      return;
+    }
+    if (!emailRegex.test(credentials.username)) {
+      this.error = 'E-mail inválido';
       return;
     }
     this.loading = true;


### PR DESCRIPTION
## Summary
- validate e-mail format in `LoginComponent.login`
- use `type="email"` on login form and show invalid e-mail message
- test invalid e-mail case

## Testing
- `npm test` *(fails: ng not found)*