### PR TITLE
Add 403 handling in interceptor

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,4 +3,5 @@
   <app-breadcrumbs *ngIf="showBreadcrumbs"></app-breadcrumbs>
   <router-outlet></router-outlet>
 </main>
+<p-toast></p-toast>
 <app-footer></app-footer>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { SharedModule } from './shared/shared.module';
 import { CoreModule } from './core/core.module';
+import { ToastModule } from 'primeng/toast';
 
 @NgModule({
   declarations: [AppComponent],
@@ -14,6 +15,7 @@ import { CoreModule } from './core/core.module';
     AppRoutingModule,
     SharedModule,
     CoreModule,
+    ToastModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -4,6 +4,8 @@ import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
 import { UserService } from './user.service';
 import { TokenInterceptor } from './token.interceptor';
+import { MessageService } from 'primeng/api';
+import { NotificationService } from './notification.service';
 
 @NgModule({
   imports: [HttpClientModule],
@@ -11,6 +13,8 @@ import { TokenInterceptor } from './token.interceptor';
     AuthService,
     AuthGuard,
     UserService,
+    MessageService,
+    NotificationService,
     { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
   ],
 })

--- a/src/app/core/notification.service.ts
+++ b/src/app/core/notification.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { MessageService } from 'primeng/api';
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService {
+  constructor(private messageService: MessageService) {}
+
+  showError(summary: string, detail?: string): void {
+    this.messageService.add({ severity: 'error', summary, detail });
+  }
+}

--- a/src/app/core/token.interceptor.spec.ts
+++ b/src/app/core/token.interceptor.spec.ts
@@ -7,23 +7,31 @@ import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { TokenInterceptor } from './token.interceptor';
 import { AuthService } from './auth.service';
+import { NotificationService } from './notification.service';
 
 describe('TokenInterceptor', () => {
   let http: HttpClient;
   let httpMock: HttpTestingController;
+  let router: jasmine.SpyObj<Router>;
+  let notification: jasmine.SpyObj<NotificationService>;
+  let auth: AuthService;
 
   beforeEach(() => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    notification = jasmine.createSpyObj('NotificationService', ['showError']);
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
         AuthService,
-        { provide: Router, useValue: { navigate: () => {} } },
+        { provide: Router, useValue: router },
+        { provide: NotificationService, useValue: notification },
         { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
       ],
     });
 
     http = TestBed.inject(HttpClient);
     httpMock = TestBed.inject(HttpTestingController);
+    auth = TestBed.inject(AuthService);
     localStorage.setItem('token', 'abc.def.ghi');
   });
 
@@ -36,5 +44,21 @@ describe('TokenInterceptor', () => {
     http.get('/data').subscribe();
     const req = httpMock.expectOne('/data');
     expect(req.request.headers.get('Authorization')).toBe('Bearer abc.def.ghi');
+  });
+
+  it('should logout and redirect on 401', () => {
+    spyOn(auth, 'logout');
+    http.get('/data').subscribe({ error: () => {} });
+    const req = httpMock.expectOne('/data');
+    req.flush({}, { status: 401, statusText: 'Unauthorized' });
+    expect(auth.logout).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['/auth/login']);
+  });
+
+  it('should notify on 403', () => {
+    http.get('/data').subscribe({ error: () => {} });
+    const req = httpMock.expectOne('/data');
+    req.flush({}, { status: 403, statusText: 'Forbidden' });
+    expect(notification.showError).toHaveBeenCalledWith('Acesso negado');
   });
 });

--- a/src/app/core/token.interceptor.ts
+++ b/src/app/core/token.interceptor.ts
@@ -9,10 +9,15 @@ import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { AuthService } from './auth.service';
 import { Router } from '@angular/router';
+import { NotificationService } from './notification.service';
 
 @Injectable()
 export class TokenInterceptor implements HttpInterceptor {
-  constructor(private auth: AuthService, private router: Router) {}
+  constructor(
+    private auth: AuthService,
+    private router: Router,
+    private notification: NotificationService
+  ) {}
 
   intercept(
     req: HttpRequest<any>,
@@ -29,6 +34,8 @@ export class TokenInterceptor implements HttpInterceptor {
         if (err.status === 401) {
           this.auth.logout();
           this.router.navigate(['/auth/login']);
+        } else if (err.status === 403) {
+          this.notification.showError('Acesso negado');
         }
         return throwError(() => err);
       })


### PR DESCRIPTION
## Summary
- show global toasts with new NotificationService
- handle HTTP 403 in TokenInterceptor
- provide MessageService and ToastModule
- cover new interceptor paths with tests

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ng not found)*